### PR TITLE
Disponibilidad: acompañantes, íconos de uso, OT internas por fecha_co…

### DIFF
--- a/acciones_disponibilidad.php
+++ b/acciones_disponibilidad.php
@@ -4,6 +4,16 @@ header('Content-Type: application/json');
 // Vista de consulta (read-only): cuadrículas semana × recurso con estatus derivados.
 // Conexión principal: mess_rrhh (para ingenieros/departamentos). Los endpoints de vehículos
 // abren su propia conexión a mess_control_vehicular ($connCV).
+
+// Acceso: exige sesión iniciada (cookie noEmpleado, igual que las vistas). Sin esto, la URL del
+// endpoint devolvía la plantilla completa de ingenieros, clientes, OTs y ausencias a cualquiera.
+$noEmpleado_cookie = isset($_COOKIE['noEmpleado']) ? trim($_COOKIE['noEmpleado']) : '';
+if ($noEmpleado_cookie === '' || !ctype_digit($noEmpleado_cookie)) {
+    http_response_code(401);
+    echo json_encode(['status' => 'error', 'message' => 'Sesión no válida. Vuelve a iniciar sesión.']);
+    exit;
+}
+
 try {
     include 'conn.php';
     mysqli_set_charset($conn, "utf8");
@@ -12,6 +22,10 @@ try {
     exit;
 }
 $accion = isset($_POST['accion']) ? $_POST['accion'] : '';
+
+// Escapa texto que va a la respuesta y termina inyectado como HTML en la celda / el tooltip
+// (detalle y titulo se pintan con innerHTML y data-html="true"). Se escapa UNA sola vez, aquí.
+function escTxt($s) { return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }
 
 // Vehículos COMODÍN (carga: estaquitas/vans). No hay distintivo en la BD -> lista por id_vehiculo.
 // ⚠ EDITAR AQUÍ si cambia la flota de carga. Placas: PH5707A,SX2202B,SV9452D,SU2914C,SV6353B,SV6343B,SX2244B,SV9819E
@@ -40,11 +54,17 @@ if ($accion == 'disponibilidadIngenieros') {
         $ingenieroF     = isset($_POST['ingeniero']) && is_array($_POST['ingeniero']) ? $_POST['ingeniero'] : [];
 
         // Marca una celda solo si la nueva prioridad es mayor o igual a la existente.
-        // $titulo (opcional) = HTML del popup (tooltip on-hover); solo lo usa 'servicio'.
-        $setCelda = function (&$celdas, $idu, $fecha, $estatus, $detalle, $p, $titulo = null) {
+        // $titulo (opcional) = HTML del popup (tooltip on-hover); $ings (opcional) = cuántos
+        // ingenieros están asignados al servicio (badge en la celda).
+        // ESCALA DE PRIORIDAD (mayor gana):
+        //   4 vacaciones · 3 laboratorio/capacitación (manual y SCOT) · 2 servicio de campo ·
+        //   1 OT interna del reporte · 0 base (asignación) / disponible
+        // El servicio de campo le GANA a la OT interna del reporte: es un compromiso con cliente y
+        // no debe quedar oculto por una OT interna larga (la OT se menciona en el popup del servicio).
+        $setCelda = function (&$celdas, $idu, $fecha, $estatus, $detalle, $p, $titulo = null, $ings = null) {
             if (!isset($celdas[$idu])) $celdas[$idu] = [];
             if (!isset($celdas[$idu][$fecha]) || $celdas[$idu][$fecha]['p'] < $p) {
-                $celdas[$idu][$fecha] = ['estatus' => $estatus, 'detalle' => $detalle, 'titulo' => $titulo, 'p' => $p];
+                $celdas[$idu][$fecha] = ['estatus' => $estatus, 'detalle' => $detalle, 'titulo' => $titulo, 'ings' => $ings, 'p' => $p];
             }
         };
 
@@ -53,11 +73,17 @@ if ($accion == 'disponibilidadIngenieros') {
         //    a diferencia del catálogo `puesto` (cuyos ids difieren entre LOCAL y PRODUCCIÓN).
         //    El filtro de Área/Laboratorio usa la columna `usuarios.zona` (texto). El 2º filtro opcional
         //    (cascada "Lab Hugo") acota por `usuarios.departamento`.
-        //    GROUP BY id_usuario: la PK de `usuarios` es `id`, no `id_usuario`, así que un mismo
-        //    id_usuario puede tener filas duplicadas; se colapsan para no repetir renglones en el grid.
+        //    GROUP BY: la PK de `usuarios` es `id`, no `id_usuario`, así que un mismo id_usuario puede
+        //    tener filas duplicadas; se colapsan para no repetir renglones en el grid.
+        //    ⚠ Hay ING/JEFE activos con `id_usuario` NULL/vacío (altas recientes que aún no existen en
+        //    SCOT). Agrupar por id_usuario a secas los colapsaba a TODOS en un solo renglón. Por eso se
+        //    agrupa por una CLAVE: el id_usuario real si lo tiene, o 'x<id>' (su PK) si no. Así cada uno
+        //    conserva su renglón, su badge de Asignación y sus vacaciones (que ligan por noEmpleado).
+        //    `id_usuario` real se conserva aparte: es lo único que se puede cruzar contra servicios/SCOT.
         //    Con ONLY_FULL_GROUP_BY (PROD) las columnas no agrupadas se agregan con MAX().
         //    LEFT JOIN departamento -> nombre del lab del ingeniero (se muestra en el grid).
-        $sqlIngs = "SELECT u.id_usuario,
+        $sqlIngs = "SELECT COALESCE(NULLIF(TRIM(u.id_usuario), ''), CONCAT('x', u.id)) AS clave,
+                           MAX(NULLIF(TRIM(u.id_usuario), '')) AS id_real,
                            MAX(u.noEmpleado) AS noEmpleado,
                            COALESCE(NULLIF(TRIM(CONCAT_WS(' ', MAX(u.nombres), MAX(u.apellidos))), ''), MAX(u.nombre)) AS nombre,
                            MAX(d.departamento) AS lab
@@ -72,37 +98,45 @@ if ($accion == 'disponibilidadIngenieros') {
             $sqlIngs .= " AND u.id_usuario IN ($ph)";
             foreach ($ingenieroF as $v) { $params[] = intval($v); $types .= 'i'; }
         }
-        $sqlIngs .= " GROUP BY u.id_usuario ORDER BY nombre";
+        $sqlIngs .= " GROUP BY COALESCE(NULLIF(TRIM(u.id_usuario), ''), CONCAT('x', u.id)) ORDER BY nombre";
         $stmt = $conn->prepare($sqlIngs);
         if ($types !== '') $stmt->bind_param($types, ...$params);
         $stmt->execute();
         $res = $stmt->get_result();
         $ingenieros = [];
-        $idsIngs = [];
-        $noEmpToId = [];
+        $idsIngs = [];    // SOLO id_usuario reales: es lo que se puede cruzar contra servicios/SCOT
+        $claveDe  = [];   // id_usuario real -> clave del renglón (para colgar las celdas)
+        $noEmpToId = [];  // noEmpleado -> clave del renglón
         while ($row = $res->fetch_assoc()) {
-            $ingenieros[] = ['id_usuario' => $row['id_usuario'], 'nombre' => $row['nombre'], 'lab' => $row['lab']];
-            $idsIngs[] = $row['id_usuario'];
+            $clave = $row['clave'];
+            $ingenieros[] = ['id_usuario' => $clave, 'id_real' => $row['id_real'], 'nombre' => $row['nombre'], 'lab' => $row['lab']];
+            if ($row['id_real'] !== null && $row['id_real'] !== '') {
+                $idsIngs[] = $row['id_real'];
+                $claveDe[$row['id_real']] = $clave;
+            }
             if ($row['noEmpleado'] !== null && $row['noEmpleado'] !== '') {
-                $noEmpToId[$row['noEmpleado']] = $row['id_usuario'];
+                $noEmpToId[$row['noEmpleado']] = $clave;
             }
         }
         $stmt->close();
 
-        if (empty($idsIngs)) {
+        if (empty($ingenieros)) {
             echo json_encode(['status' => 'success', 'ingenieros' => [], 'celdas' => (object)[]]);
             exit;
         }
 
         $celdas = [];
-        $ph = implode(',', array_fill(0, count($idsIngs), '?'));
+        // Placeholders para las consultas que cruzan por id_usuario real. Si NINGÚN ingeniero del
+        // filtro tiene id_usuario, esos bloques se omiten (un IN () vacío es un error de sintaxis).
+        $hayIds = !empty($idsIngs);
+        $ph = $hayIds ? implode(',', array_fill(0, count($idsIngs), '?')) : '';
 
-        // 1b. Asignación -> estatus BASE por ingeniero (default de la celda, prioridad 0)
-        //     'Servicio en sitio 100' -> disponible ; Laboratorio/Jefatura/Administración -> enlaboratorio
-        //     La tabla se liga por `noEmpleado` (más estable que id_usuario, que puede ser NULL/duplicado);
-        //     se traduce a id_usuario con $noEmpToId para colgar el dato en cada ingeniero del grid.
-        //     Resiliente: si la tabla aún no existe (migración pendiente), degrada a base 'disponible'.
-        $baseByIng = [];
+        // 1b. Asignación del ingeniero (badge bajo su nombre en el grid).
+        //     La tabla `planeacion_asignacion_ingenieros` se liga por `noEmpleado` (más estable que
+        //     id_usuario, que puede ser NULL/duplicado); se traduce a la clave del renglón con $noEmpToId.
+        //     NOTA: desde 2026-08-05 la Asignación ya NO decide el color de la celda vacía — el default
+        //     es 'En laboratorio' para todos. Solo se muestra como dato informativo.
+        //     Resiliente: si la tabla no existe, degrada a "Sin asignación" sin romper el grid.
         $asigByIng = [];
         if (!empty($noEmpToId)) {
             try {
@@ -117,11 +151,9 @@ if ($accion == 'disponibilidadIngenieros') {
                     $idU = isset($noEmpToId[$row['noEmpleado']]) ? $noEmpToId[$row['noEmpleado']] : null;
                     if ($idU === null) continue;
                     $asigByIng[$idU] = $row['asignacion'];
-                    $baseByIng[$idU] = (stripos($row['asignacion'], 'Servicio') !== false) ? 'disponible' : 'enlaboratorio';
                 }
                 $stmt->close();
             } catch (Throwable $e) {
-                $baseByIng = [];
                 $asigByIng = [];
             }
         }
@@ -153,98 +185,163 @@ if ($accion == 'disponibilidadIngenieros') {
             }
         }
 
-        // 2. Servicios planeados -> 'servicio' (prioridad 1)
+        // 2. Servicios planeados -> 'servicio' (prioridad 2)
         //    Incluye los CERRADOS (estatus 'Cerrada'): se muestran IGUAL que uno activo (mismo color café);
         //    el estatus real va en el popup. Solo se excluyen cancelados y el marcador de captura-Ventas.
-        //    Popup (tooltip HTML on-hover, estilo Disponibilidad de Vehículos): cliente / fecha compromiso /
-        //    hora / estatus / ciudad / OT.
-        $escServ = function ($s) { return htmlspecialchars($s ?? '', ENT_QUOTES, 'UTF-8'); };
-        $sqlServ = "SELECT engineer, engineer2, engineer3, ds_cliente, city, area, order_code, estatus,
-                           DATE(start_date) AS fecha, TIME(start_date) AS hora
-                    FROM servicios_planeados_mess
-                    WHERE (engineer IN ($ph) OR engineer2 IN ($ph) OR engineer3 IN ($ph))
-                      AND DATE(start_date) BETWEEN ? AND ?
-                      AND estatus NOT IN ('Cancelada','CanceladaV','CanceladaLab','Solicitadoventas')";
-        $stmt = $conn->prepare($sqlServ);
-        $typesS = str_repeat('i', count($idsIngs) * 3) . 'ss';
-        $paramsS = array_merge($idsIngs, $idsIngs, $idsIngs, [$fechaInicio, $fechaFin]);
-        $stmt->bind_param($typesS, ...$paramsS);
-        $stmt->execute();
-        $res = $stmt->get_result();
-        while ($row = $res->fetch_assoc()) {
-            $detalle = trim(($row['ds_cliente'] ?: 'S/C') . ($row['city'] ? ' · ' . $row['city'] : ''));
-            $hora = (!empty($row['hora']) && $row['hora'] !== '00:00:00') ? substr($row['hora'], 0, 5) : '—';
-            $titulo = "<i class='fas fa-briefcase'></i> <b>" . $escServ($row['ds_cliente'] ?: 'S/C') . "</b><br>"
-                    . "Fecha compromiso: " . $escServ($row['fecha']) . "<br>"
-                    . "Hora: " . $escServ($hora) . "<br>"
-                    . "Estatus: " . $escServ($row['estatus'] ?: '-') . "<br>"
-                    . "Ciudad: " . $escServ($row['city'] ?: '-') . "<br>"
-                    . "OT: " . $escServ($row['order_code'] ?: 's/OT');
-            foreach (['engineer', 'engineer2', 'engineer3'] as $c) {
-                $idu = $row[$c];
-                if ($idu && in_array($idu, $idsIngs)) {
-                    $setCelda($celdas, $idu, $row['fecha'], 'servicio', $detalle, 1, $titulo);
+        //    Un servicio puede llevar hasta 3 ingenieros (engineer/engineer2/engineer3): la celda muestra un
+        //    badge con CUÁNTOS son y el popup los lista por nombre. Los nombres se resuelven en una 2ª
+        //    consulta y no con JOINs, porque `usuarios.id_usuario` no es único y los JOINs duplicarían filas.
+        $serviciosRows = [];
+        $idsNombre = [];
+        if ($hayIds) {
+            $sqlServ = "SELECT engineer, engineer2, engineer3, ds_cliente, city, area, order_code, estatus,
+                               DATE(start_date) AS fecha, TIME(start_date) AS hora
+                        FROM servicios_planeados_mess
+                        WHERE (engineer IN ($ph) OR engineer2 IN ($ph) OR engineer3 IN ($ph))
+                          AND DATE(start_date) BETWEEN ? AND ?
+                          AND estatus NOT IN ('Cancelada','CanceladaV','CanceladaLab','Solicitadoventas')";
+            $stmt = $conn->prepare($sqlServ);
+            $typesS = str_repeat('i', count($idsIngs) * 3) . 'ss';
+            $paramsS = array_merge($idsIngs, $idsIngs, $idsIngs, [$fechaInicio, $fechaFin]);
+            $stmt->bind_param($typesS, ...$paramsS);
+            $stmt->execute();
+            $res = $stmt->get_result();
+            while ($row = $res->fetch_assoc()) {
+                $serviciosRows[] = $row;
+                foreach (['engineer', 'engineer2', 'engineer3'] as $c) {
+                    if (!empty($row[$c])) $idsNombre[intval($row[$c])] = true;
                 }
             }
+            $stmt->close();
         }
-        $stmt->close();
 
-        // 3. Lab / capacitación (tabla nueva) -> prioridad 2
-        $sqlMan = "SELECT id_usuario, fecha, estatus, area, comentario
-                   FROM planeacion_disponibilidad_ingenieros
-                   WHERE id_usuario IN ($ph) AND fecha BETWEEN ? AND ?";
-        $stmt = $conn->prepare($sqlMan);
-        $typesM = str_repeat('i', count($idsIngs)) . 'ss';
-        $paramsM = array_merge($idsIngs, [$fechaInicio, $fechaFin]);
-        $stmt->bind_param($typesM, ...$paramsM);
-        $stmt->execute();
-        $res = $stmt->get_result();
-        while ($row = $res->fetch_assoc()) {
-            if (stripos($row['estatus'], 'capac') !== false)        $est = 'capacitacion';
-            elseif (stripos($row['estatus'], 'interna') !== false)  $est = 'otinterna';   // OT interna
-            else                                                    $est = 'enlaboratorio';
-            $detalle = trim(($row['area'] ?: '') . ($row['comentario'] ? ' · ' . $row['comentario'] : ''));
-            $setCelda($celdas, $row['id_usuario'], $row['fecha'], $est, $detalle, 2);
+        // Nombres de TODOS los ingenieros de esos servicios, incluidos los que el filtro dejó fuera del
+        // grid (el conteo debe reflejar el equipo completo del servicio, no solo lo que se está viendo).
+        $nombrePorId = [];
+        if (!empty($idsNombre)) {
+            $idsN = array_keys($idsNombre);
+            $phNom = implode(',', array_fill(0, count($idsN), '?'));
+            $stmt = $conn->prepare("SELECT id_usuario,
+                                           COALESCE(NULLIF(TRIM(CONCAT_WS(' ', nombres, apellidos)), ''), nombre) AS nombre
+                                    FROM usuarios WHERE id_usuario IN ($phNom)");
+            $stmt->bind_param(str_repeat('i', count($idsN)), ...$idsN);
+            $stmt->execute();
+            $resN = $stmt->get_result();
+            while ($r = $resN->fetch_assoc()) {
+                if (!isset($nombrePorId[$r['id_usuario']])) $nombrePorId[$r['id_usuario']] = $r['nombre'];
+            }
+            $stmt->close();
         }
-        $stmt->close();
+
+        foreach ($serviciosRows as $row) {
+            // Equipo del servicio (1 a 3 ingenieros); el array se llavea por id -> dedupe si se repite.
+            $asignados = [];
+            foreach (['engineer', 'engineer2', 'engineer3'] as $c) {
+                $idu = $row[$c];
+                if (empty($idu)) continue;
+                $asignados[$idu] = isset($nombrePorId[$idu]) ? $nombrePorId[$idu] : ('Ing. ' . $idu);
+            }
+
+            $detalle = escTxt(trim(($row['ds_cliente'] ?: 'S/C') . ($row['city'] ? ' · ' . $row['city'] : '')));
+            $hora = (!empty($row['hora']) && $row['hora'] !== '00:00:00') ? substr($row['hora'], 0, 5) : '—';
+            $encabezado = "<i class='fas fa-briefcase'></i> <b>" . escTxt($row['ds_cliente'] ?: 'S/C') . "</b><br>";
+            $pie = "Fecha compromiso: " . escTxt($row['fecha']) . "<br>"
+                 . "Hora: " . escTxt($hora) . "<br>"
+                 . "Estatus: " . escTxt($row['estatus'] ?: '-') . "<br>"
+                 . "Ciudad: " . escTxt($row['city'] ?: '-') . "<br>"
+                 . "OT: " . escTxt($row['order_code'] ?: 's/OT');
+
+            // El badge y la lista son los ACOMPAÑANTES: el ingeniero del renglón se excluye a sí mismo
+            // (verlo repetido en su propia celda no aporta). Por eso el popup se arma por ingeniero y no
+            // una sola vez: en un servicio de 2, cada uno ve al otro y el badge dice 1 en ambos renglones.
+            // Si va solo, no hay badge ni lista.
+            foreach (array_keys($asignados) as $idu) {
+                if (!isset($claveDe[$idu])) continue;
+                $acomp = $asignados;
+                unset($acomp[$idu]);
+                $nAcomp = count($acomp);
+                $bloque = '';
+                if ($nAcomp > 0) {
+                    $bloque = "<i class='fas fa-users'></i> "
+                            . ($nAcomp === 1 ? "Acompaña:" : "Acompañan (" . $nAcomp . "):") . "<br>";
+                    foreach ($acomp as $nom) { $bloque .= '&nbsp;&nbsp;• ' . escTxt($nom) . '<br>'; }
+                }
+                $setCelda($celdas, $claveDe[$idu], $row['fecha'], 'servicio', $detalle, 2,
+                          $encabezado . $bloque . $pie, $nAcomp > 0 ? $nAcomp : null);
+            }
+        }
+
+        // 3. Lab / capacitación / OT interna capturadas a mano (tabla nueva) -> prioridad 3
+        //    Es captura explícita de un planeador, así que pesa más que lo derivado del reporte.
+        if ($hayIds) {
+            $sqlMan = "SELECT id_usuario, fecha, estatus, area, comentario
+                       FROM planeacion_disponibilidad_ingenieros
+                       WHERE id_usuario IN ($ph) AND fecha BETWEEN ? AND ?";
+            $stmt = $conn->prepare($sqlMan);
+            $typesM = str_repeat('i', count($idsIngs)) . 'ss';
+            $paramsM = array_merge($idsIngs, [$fechaInicio, $fechaFin]);
+            $stmt->bind_param($typesM, ...$paramsM);
+            $stmt->execute();
+            $res = $stmt->get_result();
+            while ($row = $res->fetch_assoc()) {
+                if (stripos($row['estatus'], 'capac') !== false)        $est = 'capacitacion';
+                elseif (stripos($row['estatus'], 'interna') !== false)  $est = 'otinterna';   // OT interna
+                else                                                    $est = 'enlaboratorio';
+                $detalle = escTxt(trim(($row['area'] ?: '') . ($row['comentario'] ? ' · ' . $row['comentario'] : '')));
+                if (!isset($claveDe[$row['id_usuario']])) continue;
+                $setCelda($celdas, $claveDe[$row['id_usuario']], $row['fecha'], $est, $detalle, 3);
+            }
+            $stmt->close();
+        }
 
         // 3b. Servicios de LABORATORIO planeados en SCOT (servicios_planeados, tipo_ot = 'LaboratoryServiceOrder')
-        //     -> 'enlaboratorio' (prioridad 2). Se ligan al ingeniero por `id_usr` = usuarios.id_usuario.
-        //     Marca cada día del rango start_date..end_date que caiga dentro de la ventana consultada.
+        //     -> 'enlaboratorio' (prioridad 3). Se ligan al ingeniero por `id_usr` = usuarios.id_usuario.
+        //     RANGO COMPLETO inicio→fin: marca cada día de `start_date`..`end_date` que caiga dentro de la
+        //     ventana consultada. (El 2026-08-05 se probó dejarlo en 1 solo día y el usuario lo revirtió:
+        //     el recorte de fechas aplicaba a los servicios INTERNOS, no a laboratorio.)
         //     Se evita el literal '0000-00-00 00:00:00' (lo rechaza el sql_mode estricto/NO_ZERO_DATE de PROD);
         //     GREATEST(start_date, IFNULL(end_date, start_date)) da el fin real y degrada a start_date si
         //     end_date es NULL o fecha cero, sin usar literales de fecha inválidos.
-        $sqlLabScot = "SELECT id_usr, ds_cliente, region, order_code,
-                              DATE(start_date) AS f_ini,
-                              DATE(GREATEST(start_date, IFNULL(end_date, start_date))) AS f_fin
-                       FROM servicios_planeados
-                       WHERE tipo_ot = 'LaboratoryServiceOrder'
-                         AND id_usr IN ($ph)
-                         AND DATE(start_date) <= ?
-                         AND DATE(GREATEST(start_date, IFNULL(end_date, start_date))) >= ?";
-        $stmt = $conn->prepare($sqlLabScot);
-        $typesL = str_repeat('i', count($idsIngs)) . 'ss';
-        $paramsL = array_merge($idsIngs, [$fechaFin, $fechaInicio]);
-        $stmt->bind_param($typesL, ...$paramsL);
-        $stmt->execute();
-        $res = $stmt->get_result();
-        while ($row = $res->fetch_assoc()) {
-            $detalle = trim($row['ds_cliente'] ?: ($row['order_code'] ?: 'Laboratorio'));
-            $ini = ($row['f_ini'] > $fechaInicio) ? $row['f_ini'] : $fechaInicio;
-            $fin = ($row['f_fin'] < $fechaFin)   ? $row['f_fin'] : $fechaFin;
-            $d = $ini;
-            while ($d <= $fin) {
-                $setCelda($celdas, $row['id_usr'], $d, 'enlaboratorio', $detalle, 2);
-                $d = date('Y-m-d', strtotime($d . ' +1 day'));
+        if ($hayIds) {
+            $sqlLabScot = "SELECT id_usr, ds_cliente, region, order_code,
+                                  DATE(start_date) AS f_ini,
+                                  DATE(GREATEST(start_date, IFNULL(end_date, start_date))) AS f_fin
+                           FROM servicios_planeados
+                           WHERE tipo_ot = 'LaboratoryServiceOrder'
+                             AND id_usr IN ($ph)
+                             AND DATE(start_date) <= ?
+                             AND DATE(GREATEST(start_date, IFNULL(end_date, start_date))) >= ?";
+            $stmt = $conn->prepare($sqlLabScot);
+            $typesL = str_repeat('i', count($idsIngs)) . 'ss';
+            $paramsL = array_merge($idsIngs, [$fechaFin, $fechaInicio]);
+            $stmt->bind_param($typesL, ...$paramsL);
+            $stmt->execute();
+            $res = $stmt->get_result();
+            while ($row = $res->fetch_assoc()) {
+                if (!isset($claveDe[$row['id_usr']])) continue;
+                $detalle = escTxt(trim($row['ds_cliente'] ?: ($row['order_code'] ?: 'Laboratorio')));
+                $ini = ($row['f_ini'] > $fechaInicio) ? $row['f_ini'] : $fechaInicio;
+                $fin = ($row['f_fin'] < $fechaFin)   ? $row['f_fin'] : $fechaFin;
+                $d = $ini;
+                while ($d <= $fin) {
+                    $setCelda($celdas, $claveDe[$row['id_usr']], $d, 'enlaboratorio', $detalle, 3);
+                    $d = date('Y-m-d', strtotime($d . ' +1 day'));
+                }
             }
+            $stmt->close();
         }
-        $stmt->close();
 
-        // 3c. OT internas (reporte cargado en `planeacion_ot_interna`) -> 'otinterna' (prioridad 2).
+        // 3c. OT internas (reporte cargado en `planeacion_ot_interna`) -> 'otinterna' (prioridad 1).
         //     La columna `Engineers` guarda NOMBRE(S) en texto (no id) -> se casa por nombre normalizado
         //     (sin acentos/mayúsculas, tolerando el orden "Apellido Nombre") contra los ingenieros del grid.
-        //     Un registro puede listar varios ingenieros (separados por , ; / & o " y "). Pinta cada día del
-        //     rango startDate..endDate. Status: TODAS. Resiliente: si la tabla no existe aún, se omite sin romper.
+        //     Un registro puede listar varios ingenieros (separados por , ; / & o " y "). Status: TODAS.
+        //     Resiliente: si la tabla no existe aún, se omite sin romper.
+        //
+        //     FIN DEL RANGO: el reporte solo trae `fecha_fin` cuando la OT está Terminada/Cancelada; las
+        //     'Asignada' (la gran mayoría) la traen vacía y antes pintaban UN SOLO DÍA aunque durara semanas.
+        //     Ahora se usa `fecha_compromiso` (dueDate) como fin. Si el compromiso es ANTERIOR al inicio
+        //     (OT vencida) no se inventa duración: se deja en 1 día, como antes.
+        $otEnCelda = [];   // [clave][fecha] => código de OT, para anotarla en el popup del servicio
         try {
             $norm = function ($s) {
                 $s = mb_strtolower(trim((string)$s), 'UTF-8');
@@ -253,42 +350,62 @@ if ($accion == 'disponibilidadIngenieros') {
                 $s = preg_replace('/[^a-z0-9 ]+/', ' ', $s);
                 return trim(preg_replace('/\s+/', ' ', $s));
             };
-            // Mapa nombre-normalizado -> id_usuario (varias variantes para maximizar el match por nombre)
+            // Mapa nombre-normalizado -> CLAVE del renglón (varias variantes para maximizar el match)
             $nombreToId = [];
-            $sqlNom = "SELECT id_usuario, nombres, apellidos, nombre FROM usuarios WHERE id_usuario IN ($ph)";
-            $stmt = $conn->prepare($sqlNom);
-            $stmt->bind_param(str_repeat('i', count($idsIngs)), ...$idsIngs);
-            $stmt->execute();
-            $resN = $stmt->get_result();
+            $sqlNom = "SELECT COALESCE(NULLIF(TRIM(id_usuario), ''), CONCAT('x', id)) AS clave,
+                              nombres, apellidos, nombre
+                       FROM usuarios
+                       WHERE estatus = 1 AND tipo_usr IN ('ING','JEFE_ENCARGADO','JEFE_LAB')";
+            $resN = $conn->query($sqlNom);
+            $clavesGrid = [];
+            foreach ($ingenieros as $ig) { $clavesGrid[$ig['id_usuario']] = true; }
             while ($r = $resN->fetch_assoc()) {
+                if (!isset($clavesGrid[$r['clave']])) continue;   // solo los que están en el grid actual
                 foreach ([trim($r['nombres'] . ' ' . $r['apellidos']),
                           trim($r['apellidos'] . ' ' . $r['nombres']),
                           $r['nombre']] as $cand) {
                     $k = $norm($cand);
-                    if ($k !== '' && !isset($nombreToId[$k])) $nombreToId[$k] = $r['id_usuario'];
+                    if ($k !== '' && !isset($nombreToId[$k])) $nombreToId[$k] = $r['clave'];
                 }
             }
-            $stmt->close();
 
+            // Fin efectivo = SOLO la fecha compromiso (decisión del usuario 2026-08-05: "solo considera
+            // fecha inicio y fecha compromiso"), y únicamente cuando es posterior o igual al inicio;
+            // si no, el propio inicio (1 día).
+            // Se IGNORA `fecha_fin` (endDate) a propósito aunque el reporte la traiga: de las 194 OT que
+            // la tienen, 186 se cerraron después de su compromiso, así que ocupaban al ingeniero 14.3 días
+            // en promedio contra 2.0 con el compromiso. El endDate real sigue saliendo en el popup.
+            $finEfectivo = "DATE(COALESCE(CASE WHEN DATE(fecha_compromiso) >= DATE(fecha_inicio)
+                                               THEN fecha_compromiso END,
+                                          fecha_inicio))";
+            // Las CANCELADAS liberan la celda (decisión del usuario 2026-08-05): una OT que ya se canceló
+            // no debe seguir ocupando al ingeniero. Se filtra por prefijo para cubrir Cancelada/Cancelado.
             $sqlOt = "SELECT codigo_ot, estatus, areas_calidad, ingenieros,
-                             DATE(fecha_inicio) AS f_ini, DATE(fecha_fin) AS f_fin
+                             DATE(fecha_inicio) AS f_ini, DATE(fecha_fin) AS f_fin,
+                             DATE(fecha_compromiso) AS f_comp, $finEfectivo AS f_fin_efec
                       FROM planeacion_ot_interna
                       WHERE fecha_inicio IS NOT NULL
+                        AND (estatus IS NULL OR LOWER(TRIM(estatus)) NOT LIKE 'cancel%')
                         AND DATE(fecha_inicio) <= ?
-                        AND DATE(IFNULL(fecha_fin, fecha_inicio)) >= ?";
+                        AND $finEfectivo >= ?";
             $stmt = $conn->prepare($sqlOt);
             $stmt->bind_param('ss', $fechaFin, $fechaInicio);
             $stmt->execute();
             $resO = $stmt->get_result();
             while ($row = $resO->fetch_assoc()) {
                 $ini = ($row['f_ini'] > $fechaInicio) ? $row['f_ini'] : $fechaInicio;
-                $finReal = !empty($row['f_fin']) ? $row['f_fin'] : $row['f_ini'];
+                $finReal = $row['f_fin_efec'];
                 $fin = ($finReal < $fechaFin) ? $finReal : $fechaFin;
-                $detalle = trim(($row['codigo_ot'] ?: 'OT interna') . ($row['areas_calidad'] ? ' · ' . $row['areas_calidad'] : ''));
-                $titulo = "<i class='fas fa-clipboard-list'></i> <b>" . $escServ($row['codigo_ot'] ?: 'OT interna') . "</b><br>"
-                        . "Áreas: " . $escServ($row['areas_calidad'] ?: '-') . "<br>"
-                        . "Estatus: " . $escServ($row['estatus'] ?: '-') . "<br>"
-                        . "Del " . $escServ($row['f_ini']) . " al " . $escServ($finReal);
+                // Se marca de dónde salió el fin, para que el popup no aparente un dato que el reporte no dio
+                $origenFin = ($finReal !== $row['f_ini']) ? ' <i>(fecha compromiso)</i>'
+                                                          : ' <i>(1 día: sin compromiso posterior al inicio)</i>';
+                // El cierre real NO ocupa la celda, pero se informa: es útil ver que se pasó del compromiso.
+                $cierreReal = !empty($row['f_fin']) ? "<br>Cerrada el: " . escTxt($row['f_fin']) : '';
+                $detalle = escTxt(trim(($row['codigo_ot'] ?: 'OT interna') . ($row['areas_calidad'] ? ' · ' . $row['areas_calidad'] : '')));
+                $titulo = "<i class='fas fa-clipboard-list'></i> <b>" . escTxt($row['codigo_ot'] ?: 'OT interna') . "</b><br>"
+                        . "Áreas: " . escTxt($row['areas_calidad'] ?: '-') . "<br>"
+                        . "Estatus: " . escTxt($row['estatus'] ?: '-') . "<br>"
+                        . "Del " . escTxt($row['f_ini']) . " al " . escTxt($finReal) . $origenFin . $cierreReal;
                 $partes = preg_split('/[,;\/&]| y /u', (string)$row['ingenieros']);
                 $vistos = [];
                 foreach ($partes as $p1) {
@@ -299,7 +416,10 @@ if ($accion == 'disponibilidadIngenieros') {
                     $vistos[$idu] = true;
                     $d = $ini;
                     while ($d <= $fin) {
-                        $setCelda($celdas, $idu, $d, 'otinterna', $detalle, 2, $titulo);
+                        $setCelda($celdas, $idu, $d, 'otinterna', $detalle, 1, $titulo);
+                        // Se registra aparte: si ese día gana el servicio de campo, la OT se anota en su popup
+                        if (!isset($otEnCelda[$idu])) $otEnCelda[$idu] = [];
+                        if (!isset($otEnCelda[$idu][$d])) $otEnCelda[$idu][$d] = $row['codigo_ot'] ?: 'OT interna';
                         $d = date('Y-m-d', strtotime($d . ' +1 day'));
                     }
                 }
@@ -309,7 +429,7 @@ if ($accion == 'disponibilidadIngenieros') {
             // tabla ausente o error -> se omiten las OT internas del reporte
         }
 
-        // 4. Vacaciones / ausencias -> prioridad 3
+        // 4. Vacaciones / ausencias -> prioridad 4 (la más alta: gana sobre todo lo demás)
         //    Cuenta desde que el empleado hace la solicitud; solo se EXCLUYE si fue RECHAZADA.
         //    Rechazada = jefe (estatus = 3) O RRHH (autorizaRH = 3) — misma regla que la app `incidencias`
         //    (acciones_solicitudempleado.php: canceladas/rechazadas = estatus=3 OR autorizaRH=3).
@@ -338,16 +458,29 @@ if ($accion == 'disponibilidadIngenieros') {
                 $f   = ($row['feinicio'] > $fechaInicio) ? $row['feinicio'] : $fechaInicio;
                 $end = ($row['fefin'] < $fechaFin) ? $row['fefin'] : $fechaFin;
                 while ($f <= $end) {
-                    $setCelda($celdas, $idu, $f, 'vacaciones', $detalle, 3);
+                    $setCelda($celdas, $idu, $f, 'vacaciones', $detalle, 4);
                     $f = date('Y-m-d', strtotime($f . ' +1 day'));
                 }
             }
             $stmt->close();
         }
 
-        // Adjuntar el estatus base, el texto de la Asignación y el enlace personalizado a cada ingeniero
+        // El servicio de campo le gana a la OT interna, pero la OT no debe desaparecer: se anota al pie
+        // del popup del servicio para que se vea que ese día el ingeniero también trae una OT interna.
+        foreach ($otEnCelda as $claveOt => $porFecha) {
+            foreach ($porFecha as $fOt => $codigoOt) {
+                if (!isset($celdas[$claveOt][$fOt])) continue;
+                $c = &$celdas[$claveOt][$fOt];
+                if ($c['estatus'] === 'servicio' && !empty($c['titulo'])) {
+                    $c['titulo'] .= "<hr style='margin:4px 0;opacity:.4'>"
+                                  . "<i class='fas fa-clipboard-list'></i> Además: OT interna " . escTxt($codigoOt);
+                }
+                unset($c);
+            }
+        }
+
+        // Adjuntar el texto de la Asignación y el enlace personalizado a cada ingeniero
         foreach ($ingenieros as &$ing) {
-            $ing['base'] = isset($baseByIng[$ing['id_usuario']]) ? $baseByIng[$ing['id_usuario']] : 'disponible';
             $ing['asignacion'] = isset($asigByIng[$ing['id_usuario']]) ? $asigByIng[$ing['id_usuario']] : '';
             $ing['enlace'] = isset($enlaceByIng[$ing['id_usuario']]) ? $enlaceByIng[$ing['id_usuario']] : '';
         }
@@ -419,10 +552,12 @@ if ($accion == 'disponibilidadVehiculos') {
 
         // Marca una celda solo si la nueva prioridad es mayor o igual a la existente.
         // Prioridad: mantenimiento (3) > servicio (2) > préstamo (1) > disponible (0).
-        $setCelda = function (&$celdas, $idv, $fecha, $estatus, $detalle, $titulo, $p) {
+        // $uso = quién trae el vehículo ese día, para el ícono de la celda:
+        //   'asignado' -> su responsable de inventario   ·   'otro' -> alguien más (préstamo u otro ing).
+        $setCelda = function (&$celdas, $idv, $fecha, $estatus, $detalle, $titulo, $p, $uso = null) {
             if (!isset($celdas[$idv])) $celdas[$idv] = [];
             if (!isset($celdas[$idv][$fecha]) || $celdas[$idv][$fecha]['p'] < $p) {
-                $celdas[$idv][$fecha] = ['estatus' => $estatus, 'detalle' => $detalle, 'titulo' => $titulo, 'p' => $p];
+                $celdas[$idv][$fecha] = ['estatus' => $estatus, 'detalle' => $detalle, 'titulo' => $titulo, 'uso' => $uso, 'p' => $p];
             }
         };
 
@@ -434,7 +569,7 @@ if ($accion == 'disponibilidadVehiculos') {
         //    comodín no tiene usuario. Filtros opcionales. Los comodines se marcan y se ordenan primero.
         // DISTINCT: un id_usuario puede casar con >1 fila en usuarios (duplicados) y multiplicar el vehículo;
         // como solo seleccionamos columnas de inventario, DISTINCT colapsa esos duplicados sin riesgo.
-        $sqlVeh = "SELECT DISTINCT inv.id_vehiculo, inv.placa, inv.marca, inv.modelo, inv.usuario, inv.area, u.zona,
+        $sqlVeh = "SELECT DISTINCT inv.id_vehiculo, inv.placa, inv.marca, inv.modelo, inv.usuario, inv.area, inv.id_usuario, u.zona,
                           (inv.id_vehiculo IN ($comodinList)) AS comodin
                    FROM inventario inv
                    LEFT JOIN mess_rrhh.usuarios u ON inv.id_usuario = u.id_usuario
@@ -481,11 +616,16 @@ if ($accion == 'disponibilidadVehiculos') {
         $ph = implode(',', array_fill(0, count($idsVeh), '?'));
 
         // 2. Préstamos AUTORIZADO/EN CURSO -> 'prestamo' (prioridad 1). Solape con el rango de la semana.
-        $sqlP = "SELECT id_vehiculo, DATE(fecha_inc_prestamo) AS ini, DATE(fecha_fin_prestamo) AS fin, Destino, motivo_us
-                 FROM prestamos
-                 WHERE id_vehiculo IN ($ph)
-                   AND estatus IN ('AUTORIZADO','EN CURSO')
-                   AND DATE(fecha_inc_prestamo) <= ? AND DATE(fecha_fin_prestamo) >= ?";
+        //    Se resuelve QUIÉN lo trae (prestamos.id_usuario -> mess_rrhh.usuarios) para el popup: el
+        //    ícono 🤝 de la celda indica que el vehículo NO lo trae su responsable de inventario.
+        $sqlP = "SELECT p.id_vehiculo, DATE(p.fecha_inc_prestamo) AS ini, DATE(p.fecha_fin_prestamo) AS fin,
+                        p.Destino, p.motivo_us, p.tipo_uso,
+                        COALESCE(NULLIF(TRIM(CONCAT_WS(' ', up.nombres, up.apellidos)), ''), up.nombre) AS quien
+                 FROM prestamos p
+                 LEFT JOIN mess_rrhh.usuarios up ON p.id_usuario = up.id_usuario
+                 WHERE p.id_vehiculo IN ($ph)
+                   AND p.estatus IN ('AUTORIZADO','EN CURSO')
+                   AND DATE(p.fecha_inc_prestamo) <= ? AND DATE(p.fecha_fin_prestamo) >= ?";
         $stmt = $connCV->prepare($sqlP);
         $typesP = str_repeat('i', count($idsVeh)) . 'ss';
         $paramsP = array_merge(array_map('intval', $idsVeh), [$fechaFin, $fechaInicio]);
@@ -493,13 +633,19 @@ if ($accion == 'disponibilidadVehiculos') {
         $stmt->execute();
         $res = $stmt->get_result();
         while ($row = $res->fetch_assoc()) {
-            $detalle = trim($row['Destino'] ?? '');
-            if ($detalle === '') $detalle = trim($row['motivo_us'] ?? '');
-            if ($detalle === '') $detalle = 'Préstamo';
+            $destino = trim($row['Destino'] ?? '');
+            if ($destino === '') $destino = trim($row['motivo_us'] ?? '');
+            if ($destino === '') $destino = 'Préstamo';
+            $detalle = escTxt($destino);
+            $titulo = "<i class='fas fa-handshake'></i> <b>Préstamo</b><br>"
+                    . "Lo trae: " . escTxt($row['quien'] ?: 'Sin resolver') . "<br>"
+                    . "Destino: " . escTxt($destino) . "<br>"
+                    . "Uso: " . escTxt($row['tipo_uso'] ?: '-') . "<br>"
+                    . "Del " . escTxt($row['ini']) . " al " . escTxt($row['fin']);
             $f   = ($row['ini'] > $fechaInicio) ? $row['ini'] : $fechaInicio;
             $end = ($row['fin'] < $fechaFin) ? $row['fin'] : $fechaFin;
             while ($f <= $end) {
-                $setCelda($celdas, $row['id_vehiculo'], $f, 'prestamo', $detalle, $detalle, 1);
+                $setCelda($celdas, $row['id_vehiculo'], $f, 'prestamo', $detalle, $titulo, 1, 'otro');
                 $f = date('Y-m-d', strtotime($f . ' +1 day'));
             }
         }
@@ -518,8 +664,9 @@ if ($accion == 'disponibilidadVehiculos') {
         $stmt->execute();
         $res = $stmt->get_result();
         while ($row = $res->fetch_assoc()) {
-            $detalle = trim($row['tipo_mantenimiento'] ?? '');
-            if ($detalle === '') $detalle = 'Mantenimiento';
+            $tipo = trim($row['tipo_mantenimiento'] ?? '');
+            if ($tipo === '') $tipo = 'Mantenimiento';
+            $detalle = escTxt($tipo);
             $setCelda($celdas, $row['id_vehiculo'], $row['fecha_programada'], 'mantenimiento', $detalle, $detalle, 3);
         }
         $stmt->close();
@@ -527,13 +674,17 @@ if ($accion == 'disponibilidadVehiculos') {
         // 4. Servicios planeados (mess_rrhh.servicios_planeados_mess, ligado por placa) -> 'servicio' (prioridad 2)
         //    Info tipo "Actividades planeadas": ing / área / OT / cliente / ciudad.
         $placaToId = [];
+        $placaToDuenio = [];   // placa -> id_usuario del responsable de inventario (para el ícono de uso)
         foreach ($vehiculos as $vv) {
-            if ($vv['placa'] !== null && $vv['placa'] !== '') $placaToId[$vv['placa']] = $vv['id_vehiculo'];
+            if ($vv['placa'] !== null && $vv['placa'] !== '') {
+                $placaToId[$vv['placa']] = $vv['id_vehiculo'];
+                $placaToDuenio[$vv['placa']] = $vv['id_usuario'];
+            }
         }
         $placas = array_keys($placaToId);
         if (!empty($placas)) {
             $phS = implode(',', array_fill(0, count($placas), '?'));
-            $sqlS = "SELECT sp.vehiculo AS placa, sp.order_code, sp.ds_cliente, sp.city, sp.area,
+            $sqlS = "SELECT sp.vehiculo AS placa, sp.order_code, sp.ds_cliente, sp.city, sp.area, sp.engineer,
                             DATE(sp.start_date) AS fecha,
                             COALESCE(NULLIF(TRIM(CONCAT_WS(' ', ue.nombres, ue.apellidos)), ''), ue.nombre) AS ing
                      FROM servicios_planeados_mess sp
@@ -548,18 +699,22 @@ if ($accion == 'disponibilidadVehiculos') {
             $stmt->bind_param($typesS, ...$paramsS);
             $stmt->execute();
             $res = $stmt->get_result();
-            $esc = function ($s) { return htmlspecialchars($s ?? '', ENT_QUOTES, 'UTF-8'); };
             while ($row = $res->fetch_assoc()) {
                 $idv = isset($placaToId[$row['placa']]) ? $placaToId[$row['placa']] : null;
                 if (!$idv) continue;
-                $corto = trim(($row['ds_cliente'] ?: 'S/C') . ($row['city'] ? ' · ' . $row['city'] : ''));
+                // ¿Lo trae su responsable de inventario o alguien más? Define el ícono de la celda.
+                $duenio = isset($placaToDuenio[$row['placa']]) ? $placaToDuenio[$row['placa']] : null;
+                $esDuenio = ($duenio !== null && $duenio !== '' && (string)$duenio === (string)$row['engineer']);
+                $uso = $esDuenio ? 'asignado' : 'otro';
+                $corto = escTxt(trim(($row['ds_cliente'] ?: 'S/C') . ($row['city'] ? ' · ' . $row['city'] : '')));
                 // Tooltip HTML estilo "Actividades planeadas" (ing / área / OT / cliente / ciudad)
-                $full = "<i class='fas fa-user'></i> <b>" . $esc($row['ing'] ?: 'S/Ing') . "</b><br>"
-                      . "Área: " . $esc($row['area'] ?: '-') . "<br>"
-                      . "OT: " . $esc($row['order_code'] ?: 's/OT') . "<br>"
-                      . "Cliente: " . $esc($row['ds_cliente'] ?: 'S/C') . "<br>"
-                      . "Ciudad: " . $esc($row['city'] ?: '-');
-                $setCelda($celdas, $idv, $row['fecha'], 'servicio', $corto, $full, 2);
+                $full = "<i class='fas fa-" . ($esDuenio ? 'user' : 'handshake') . "'></i> <b>" . escTxt($row['ing'] ?: 'S/Ing') . "</b>"
+                      . ($esDuenio ? " <i>(responsable)</i>" : " <i>(no es su responsable)</i>") . "<br>"
+                      . "Área: " . escTxt($row['area'] ?: '-') . "<br>"
+                      . "OT: " . escTxt($row['order_code'] ?: 's/OT') . "<br>"
+                      . "Cliente: " . escTxt($row['ds_cliente'] ?: 'S/C') . "<br>"
+                      . "Ciudad: " . escTxt($row['city'] ?: '-');
+                $setCelda($celdas, $idv, $row['fecha'], 'servicio', $corto, $full, 2, $uso);
             }
             $stmt->close();
         }

--- a/carga_sabana.php
+++ b/carga_sabana.php
@@ -1,3 +1,28 @@
+<?php
+    session_start();
+    include 'conn.php';
+    if(!isset($_COOKIE['noEmpleado']) || $_COOKIE['noEmpleado'] == ''){
+        echo '<script>window.location.assign("index")</script>';
+        exit;
+    }
+
+    // Estado del reporte de OT internas, para que se vea de entrada si está al día.
+    // El grid de Disponibilidad solo pinta las OT que estén en esta tabla: si nadie recarga el
+    // reporte, el morado desaparece del tablero sin ningún aviso (ya pasó).
+    $otEstado = ['existe' => false, 'filas' => 0, 'min' => null, 'max' => null, 'dias' => null];
+    if ($resOt = @$conn->query("SELECT COUNT(*) filas, MIN(DATE(fecha_inicio)) mn, MAX(DATE(fecha_inicio)) mx,
+                                       DATEDIFF(CURDATE(), MAX(DATE(fecha_inicio))) dias
+                                FROM planeacion_ot_interna")) {
+        $otEstado['existe'] = true;
+        if ($f = $resOt->fetch_assoc()) {
+            $otEstado['filas'] = (int)$f['filas'];
+            $otEstado['min']   = $f['mn'];
+            $otEstado['max']   = $f['mx'];
+            $otEstado['dias']  = $f['dias'];
+        }
+    }
+    $eOt = function ($s) { return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); };
+?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
@@ -58,6 +83,68 @@
                                     </div>
                                 </div>
                             </div>
+
+                            <!-- ============ REPORTE DE OT INTERNAS (SERV INTERNOS) ============ -->
+                            <!-- Proceso independiente del de la sábana: otro archivo, otra tabla y otro
+                                 destino. Alimenta las celdas moradas "OT interna" del tablero de
+                                 Disponibilidad de Ingenieros. Recargar NO duplica (UPSERT por orderCode). -->
+                            <div class="card shadow mb-4">
+                                <div class="card-header py-3 d-flex justify-content-between align-items-center">
+                                    <h6 class="m-0 font-weight-bold text-primary"><i class="fas fa-clipboard-list"></i> Reporte de OT internas (Servicios internos)</h6>
+                                    <a href="disponibilidadIngenieros" class="small"><i class="fas fa-user-clock"></i> Ver tablero</a>
+                                </div>
+                                <div class="card-body">
+                                    <p class="text-muted mb-3">
+                                        Es lo que pinta las celdas moradas <b>"OT interna"</b> en Disponibilidad de Ingenieros.
+                                        Sube el CSV tal cual sale del sistema de OTs; volver a cargarlo <b>no duplica</b>:
+                                        actualiza las que ya existen y agrega las nuevas.
+                                    </p>
+
+                                    <?php
+                                        $claseOt = 'border-left: 4px solid #4e73df; background:#f8f9fc;';
+                                        if (!$otEstado['existe'] || $otEstado['filas'] === 0)          $claseOt = 'border-left: 4px solid #e74a3b; background:#fdf3f2;';
+                                        elseif ($otEstado['dias'] !== null && $otEstado['dias'] > 7)   $claseOt = 'border-left: 4px solid #e0a800; background:#fffbf0;';
+                                    ?>
+                                    <div class="mb-3 p-3 rounded" style="<?php echo $claseOt; ?>">
+                                        <?php if (!$otEstado['existe']): ?>
+                                            <b class="text-danger"><i class="fas fa-exclamation-triangle"></i> La tabla no existe en esta base de datos.</b><br>
+                                            <span class="text-muted">Hay que crearla antes de poder cargar el reporte. Mientras tanto el tablero no pinta ninguna OT interna.</span>
+                                        <?php elseif ($otEstado['filas'] === 0): ?>
+                                            <b class="text-danger"><i class="fas fa-exclamation-triangle"></i> No hay ningún reporte cargado.</b><br>
+                                            <span class="text-muted">El tablero no está mostrando ninguna OT interna.</span>
+                                        <?php else: ?>
+                                            <b><i class="fas fa-database"></i> Reporte actual:</b>
+                                            <?php echo $otEstado['filas']; ?> OT
+                                            &nbsp;·&nbsp; fechas de inicio del <b><?php echo $eOt($otEstado['min']); ?></b>
+                                            al <b><?php echo $eOt($otEstado['max']); ?></b>
+                                            <?php if ($otEstado['dias'] !== null && $otEstado['dias'] > 7): ?>
+                                                <br><span class="text-warning-emphasis">
+                                                    <i class="fas fa-clock"></i> <b>Lleva <?php echo (int)$otEstado['dias']; ?> días sin actualizarse.</b>
+                                                    Las OT posteriores a esa fecha no aparecen en el tablero.
+                                                </span>
+                                            <?php endif; ?>
+                                        <?php endif; ?>
+                                    </div>
+
+                                    <form id="form-ot" enctype="multipart/form-data">
+                                        <div class="row align-items-end">
+                                            <div class="col-md-8 mb-3">
+                                                <label class="form-label font-weight-bold text-primary">Archivo de OT internas (SERV INTERNOS)</label>
+                                                <input class="form-control" type="file" id="archivo_ot" name="archivo" accept=".csv" required>
+                                                <small class="text-muted">Encabezados en inglés: <code>orderCode</code>, <code>status</code>, <code>Engineers</code>, <code>startDate</code>, <code>dueDate</code>…</small>
+                                            </div>
+                                            <div class="col-md-4 mb-3">
+                                                <button type="submit" id="btn-ot" class="btn btn-primary w-100">
+                                                    <i class="fas fa-cloud-upload-alt"></i> Cargar OT internas
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </form>
+
+                                    <div id="resultado-ot" class="mt-2" style="display:none;"></div>
+                                </div>
+                            </div>
+
                         </div>
                     </div>
                 </div>
@@ -138,6 +225,69 @@
                     }
                 }
             });
+        }
+
+        // ============ REPORTE DE OT INTERNAS ============
+        // Proceso aparte del de la sábana: es un solo archivo chico, así que va de un tiro
+        // (sin lotes ni barra de progreso). La importación real vive en lib_ot_interna.php,
+        // compartida con el comando `php cargar_ot_interna.php`.
+        function escOt(s) {
+            return String(s == null ? '' : s).replace(/&/g,'&amp;').replace(/</g,'&lt;')
+                                             .replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+        }
+
+        $('#form-ot').on('submit', function(e) {
+            e.preventDefault();
+            var btn = $('#btn-ot').prop('disabled', true).html('<i class="fas fa-spinner fa-spin"></i> Cargando...');
+            $('#resultado-ot').hide();
+
+            $.ajax({
+                url: 'procesar_ot_interna.php', type: 'POST', dataType: 'json',
+                data: new FormData(this), contentType: false, processData: false,
+                success: function(res) {
+                    if (res.status !== 'success') {
+                        Swal.fire('No se pudo cargar', res.message || 'Error desconocido', 'error');
+                        return;
+                    }
+                    pintarResultadoOt(res);
+                    Swal.fire({
+                        icon: 'success', title: 'Reporte cargado',
+                        html: '<b>' + res.filas + '</b> OT internas cargadas.<br>Ya se reflejan en el tablero de Disponibilidad.'
+                    });
+                },
+                error: function(xhr) {
+                    Swal.fire('Error', xhr.status === 401 ? 'Tu sesión expiró. Vuelve a iniciar sesión.'
+                                                          : 'Hubo un problema de comunicación con el servidor.', 'error');
+                },
+                complete: function() {
+                    $('#btn-ot').prop('disabled', false).html('<i class="fas fa-cloud-upload-alt"></i> Cargar OT internas');
+                }
+            });
+        });
+
+        function pintarResultadoOt(res) {
+            var h = '<div class="alert alert-success mb-2"><b><i class="fas fa-check-circle"></i> ' +
+                    res.filas + ' OT cargadas</b> desde <i>' + escOt(res.archivo) + '</i>';
+            if (res.rango && res.rango.min) {
+                h += '<br>Fechas de inicio: <b>' + escOt(res.rango.min) + '</b> al <b>' + escOt(res.rango.max) + '</b>';
+            }
+            if (res.omitidas > 0)  { h += '<br><span class="text-muted">Renglones omitidos (sin orderCode): ' + res.omitidas + '</span>'; }
+            if (res.sin_fecha > 0) { h += '<br><span class="text-muted">OT sin fecha de inicio (no se pintan): ' + res.sin_fecha + '</span>'; }
+            h += '</div>';
+
+            // Los nombres que no casan son la falla silenciosa de este módulo: el cruce con el
+            // ingeniero es por texto, así que un typo deja esa OT sin pintarse y nadie se entera.
+            var sm = res.sin_match || {}, nombres = Object.keys(sm);
+            if (nombres.length) {
+                h += '<div class="alert alert-warning mb-2"><b><i class="fas fa-exclamation-triangle"></i> ' +
+                     nombres.length + ' nombre(s) del reporte no existen en el sistema.</b>' +
+                     '<div class="small mb-2">Esas OT se guardaron, pero <b>no se le pintan a nadie</b> en el tablero. ' +
+                     'Casi siempre es un typo en el reporte, o alguien que no está dado de alta como ingeniero activo.</div>' +
+                     '<ul class="small mb-0" style="max-height:200px; overflow-y:auto;">';
+                nombres.forEach(function(n) { h += '<li>' + escOt(n) + ' <span class="text-muted">(' + sm[n] + ' OT)</span></li>'; });
+                h += '</ul></div>';
+            }
+            $('#resultado-ot').html(h).show();
         }
 
         function finalizarProceso() {

--- a/cargar_ot_interna.php
+++ b/cargar_ot_interna.php
@@ -3,64 +3,23 @@
 // Uso (CLI):  php cargar_ot_interna.php "ruta/al/reporte.csv"
 //             (por defecto lee .claude/SERV INTERNOS.csv)
 // Reejecutar = recarga incremental (UPSERT por orderCode; no duplica).
-// El reporte trae fechas en formato DD/MM/YYYY HH:MM y literales 'S/R' / "'-" que se guardan como NULL.
+//
+// La lógica vive en `lib_ot_interna.php`, COMPARTIDA con la carga desde el navegador
+// (tarjeta "Reporte de OT internas" en `carga_sabana.php`), para que las dos vías se comporten igual.
 if (php_sapi_name() !== 'cli') { die('Solo CLI'); }
 require __DIR__ . '/conn.php';
+require __DIR__ . '/lib_ot_interna.php';
 
 $ruta = $argv[1] ?? (__DIR__ . '/.claude/SERV INTERNOS.csv');
 if (!is_file($ruta)) { fwrite(STDERR, "No existe el archivo: $ruta\n"); exit(1); }
 
-$esVacio = function ($v) {
-    $v = trim((string)$v);
-    return $v === '' || strcasecmp($v, 'S/R') === 0 || $v === '-' || $v === "'-";
-};
-$parseFecha = function ($v) use ($esVacio) {
-    if ($esVacio($v)) return null;
-    $v = trim($v);
-    $dt = DateTime::createFromFormat('d/m/Y H:i', $v) ?: DateTime::createFromFormat('d/m/Y', $v);
-    return $dt ? $dt->format('Y-m-d H:i:s') : null;
-};
-$limpiaNum = function ($v) use ($esVacio) { return $esVacio($v) ? null : trim($v); };
+$r = otiImportar($conn, $ruta);
+if (!$r['ok']) { fwrite(STDERR, $r['mensaje'] . "\n"); exit(1); }
 
-$fh = fopen($ruta, 'r');
-$headers = fgetcsv($fh);
-if (!$headers) { fwrite(STDERR, "Reporte vacío o ilegible.\n"); exit(1); }
-$headers = array_map(function ($h) { return trim($h, " \t\r\n\xEF\xBB\xBF"); }, $headers);
-$idx = array_flip($headers);
-$col = function ($row, $name) use ($idx) { return isset($idx[$name]) && isset($row[$idx[$name]]) ? trim($row[$idx[$name]]) : null; };
-
-// El CSV trae encabezados en inglés; la tabla usa columnas en español (mapeo en $col(...) más abajo).
-$sql = "INSERT INTO planeacion_ot_interna
-        (codigo_ot,estatus,areas_calidad,ingenieros,fecha_creacion,fecha_compromiso,fecha_inicio,fecha_fin,fecha_cierre,tiempo_estimado,tiempo_trabajado,tiempo_registrado)
-        VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
-        ON DUPLICATE KEY UPDATE estatus=VALUES(estatus), areas_calidad=VALUES(areas_calidad), ingenieros=VALUES(ingenieros),
-            fecha_creacion=VALUES(fecha_creacion), fecha_compromiso=VALUES(fecha_compromiso), fecha_inicio=VALUES(fecha_inicio), fecha_fin=VALUES(fecha_fin),
-            fecha_cierre=VALUES(fecha_cierre), tiempo_estimado=VALUES(tiempo_estimado), tiempo_trabajado=VALUES(tiempo_trabajado), tiempo_registrado=VALUES(tiempo_registrado)";
-$stmt = $conn->prepare($sql);
-
-$n = 0; $skip = 0;
-while (($row = fgetcsv($fh)) !== false) {
-    if (count(array_filter($row, function ($x) { return trim((string)$x) !== ''; })) === 0) continue; // línea vacía
-    $orderCode = $col($row, 'orderCode');
-    if ($orderCode === null || $orderCode === '') { $skip++; continue; }
-    $vals = [
-        $orderCode,
-        $col($row, 'status'),
-        $col($row, 'qualityAreas'),
-        $col($row, 'Engineers'),
-        $parseFecha($col($row, 'created')),
-        $parseFecha($col($row, 'dueDate')),
-        $parseFecha($col($row, 'startDate')),
-        $parseFecha($col($row, 'endDate')),
-        $parseFecha($col($row, 'closeDate')),
-        $limpiaNum($col($row, 'estimatedTime')),
-        $limpiaNum($col($row, 'workTime')),
-        $limpiaNum($col($row, 'timedTime')),
-    ];
-    $stmt->bind_param('ssssssssssss', ...$vals);
-    $stmt->execute();
-    $n++;
-}
-fclose($fh);
 echo "Reporte: $ruta\n";
-echo "Filas cargadas (insert/update): $n  |  omitidas: $skip\n";
+echo "Filas cargadas (insert/update): {$r['filas']}  |  omitidas: {$r['omitidas']}\n";
+if ($r['rango']['min']) { echo "Rango de fechas de inicio: {$r['rango']['min']} a {$r['rango']['max']}\n"; }
+if (!empty($r['sin_match'])) {
+    echo "\n⚠ Nombres del reporte que NO existen en `usuarios` (esas OT no se le pintan a nadie):\n";
+    foreach ($r['sin_match'] as $nom => $veces) { echo "   - $nom  ($veces OT)\n"; }
+}

--- a/cargar_zonas.php
+++ b/cargar_zonas.php
@@ -1,0 +1,89 @@
+<?php
+// Aplica a `usuarios` las correcciones capturadas a mano en el CSV de pendientes.
+// Uso (CLI):  php cargar_zonas.php [ruta.csv] [--aplicar]
+//             (por defecto lee .claude/ZONAS_PENDIENTES.csv y solo SIMULA)
+//
+// Resuelve dos pendientes del módulo de Disponibilidad, ambos llaveados por `noEmpleado`:
+//   ZONA        -> `usuarios.zona`, que alimenta el filtro "Área / Laboratorio" de los dos grids.
+//                  Sin zona, el ingeniero solo aparece en "Todas" y es invisible bajo cualquier filtro.
+//   ID_USUARIO  -> `usuarios.id_usuario`, la llave con la que se cruzan servicios, SCOT y la captura
+//                  manual de laboratorio. Los que la traen vacía salen en el grid (por la clave
+//                  sintética del endpoint) pero nunca reflejan servicios.
+//
+// Columnas del CSV: noEmpleado, nombre, departamento, tipo_usr, zona_actual, ZONA, id_usuario_actual, ID_USUARIO
+// Solo se escriben las celdas ZONA / ID_USUARIO que estén llenas; lo vacío se ignora (recargable).
+// Sin --aplicar no toca nada: imprime el plan para revisarlo antes.
+if (php_sapi_name() !== 'cli') { die('Solo CLI'); }
+require __DIR__ . '/conn.php';
+
+$args    = array_slice($argv, 1);
+$aplicar = in_array('--aplicar', $args, true);
+$rutas   = array_values(array_filter($args, function ($a) { return strpos($a, '--') !== 0; }));
+$ruta    = $rutas[0] ?? (__DIR__ . '/.claude/ZONAS_PENDIENTES.csv');
+if (!is_file($ruta)) { fwrite(STDERR, "No existe el archivo: $ruta\n"); exit(1); }
+
+$fh = fopen($ruta, 'r');
+$headers = fgetcsv($fh);
+if (!$headers) { fwrite(STDERR, "CSV vacío o ilegible.\n"); exit(1); }
+$headers = array_map(function ($h) { return trim($h, " \t\r\n\xEF\xBB\xBF"); }, $headers);
+$idx = array_flip($headers);
+foreach (['noEmpleado', 'ZONA', 'ID_USUARIO'] as $req) {
+    if (!isset($idx[$req])) { fwrite(STDERR, "Falta la columna '$req' en el CSV.\n"); exit(1); }
+}
+$col = function ($row, $name) use ($idx) {
+    return isset($idx[$name]) && isset($row[$idx[$name]]) ? trim($row[$idx[$name]]) : '';
+};
+
+// Zonas válidas = las que YA existen en la población del grid. Si el CSV trae una zona nueva se
+// avisa (no se bloquea): puede ser un área legítima que aún no tiene a nadie asignado.
+$zonasOk = [];
+if ($r = $conn->query("SELECT DISTINCT zona FROM usuarios
+                       WHERE estatus = 1 AND tipo_usr IN ('ING','JEFE_ENCARGADO','JEFE_LAB')
+                         AND zona IS NOT NULL AND TRIM(zona) <> ''")) {
+    while ($z = $r->fetch_assoc()) { $zonasOk[mb_strtolower($z['zona'])] = $z['zona']; }
+}
+
+$stZona = $conn->prepare("UPDATE usuarios SET zona = ? WHERE noEmpleado = ?");
+$stIdU  = $conn->prepare("UPDATE usuarios SET id_usuario = ? WHERE noEmpleado = ?");
+
+$nZona = 0; $nId = 0; $avisos = []; $saltados = 0;
+while (($row = fgetcsv($fh)) !== false) {
+    if (count(array_filter($row, function ($x) { return trim((string)$x) !== ''; })) === 0) continue;
+    $noEmp  = $col($row, 'noEmpleado');
+    $nombre = $col($row, 'nombre');
+    if ($noEmp === '' || !ctype_digit($noEmp)) { $saltados++; continue; }
+
+    $zona = $col($row, 'ZONA');
+    if ($zona !== '') {
+        if (!isset($zonasOk[mb_strtolower($zona)])) {
+            $avisos[] = "zona nueva '$zona' ($nombre) — se creará al aplicar";
+        } elseif ($zonasOk[mb_strtolower($zona)] !== $zona) {
+            // Reusa la grafía exacta ya existente: el filtro compara con `zona = ?` (match exacto)
+            $zona = $zonasOk[mb_strtolower($zona)];
+        }
+        echo "  ZONA        $noEmp  " . str_pad(mb_substr($nombre, 0, 32), 34) . "-> $zona\n";
+        if ($aplicar) { $stZona->bind_param('si', $zona, $noEmp); $stZona->execute(); }
+        $nZona++;
+    }
+
+    $idU = $col($row, 'ID_USUARIO');
+    if ($idU !== '') {
+        if (!ctype_digit($idU)) { $avisos[] = "ID_USUARIO '$idU' de $nombre no es numérico — se omite"; continue; }
+        // Un id_usuario repetido colapsaría los dos registros en un solo renglón del grid
+        $chk = $conn->prepare("SELECT COUNT(*) c FROM usuarios WHERE id_usuario = ? AND noEmpleado <> ?");
+        $chk->bind_param('ii', $idU, $noEmp);
+        $chk->execute();
+        $ya = $chk->get_result()->fetch_assoc()['c'];
+        $chk->close();
+        if ($ya > 0) { $avisos[] = "ID_USUARIO $idU ($nombre) YA lo usa otro usuario — se omite"; continue; }
+        echo "  ID_USUARIO  $noEmp  " . str_pad(mb_substr($nombre, 0, 32), 34) . "-> $idU\n";
+        if ($aplicar) { $stIdU->bind_param('ii', $idU, $noEmp); $stIdU->execute(); }
+        $nId++;
+    }
+}
+fclose($fh);
+
+echo "\nArchivo: $ruta\n";
+echo ($aplicar ? "APLICADO" : "SIMULACIÓN (usa --aplicar para escribir)") . "\n";
+echo "  zonas: $nZona   ·   id_usuario: $nId" . ($saltados ? "   ·   renglones saltados: $saltados" : '') . "\n";
+foreach ($avisos as $a) { echo "  ⚠ $a\n"; }

--- a/disponibilidadIngenieros.php
+++ b/disponibilidadIngenieros.php
@@ -1,8 +1,9 @@
 <?php
     session_start();
     include 'conn.php';
-    if($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null){
+    if(!isset($_COOKIE['noEmpleado']) || $_COOKIE['noEmpleado'] == ''){
         echo '<script>window.location.assign("index")</script>';
+        exit;   // sin exit la página se seguía enviando completa antes de que el navegador redirigiera
     }
 ?>
 <!DOCTYPE html>
@@ -39,6 +40,10 @@
         .grid-disp tbody tr { border-bottom: 2px solid #dee2e6; }
         .celda-disp { min-height: 46px; line-height: 1.25; font-size: 11px; font-weight: 600; }
         .celda-disp small { display:block; font-weight: 400; font-size: 10px; opacity: 0.85; }
+        /* Cuántos ingenieros están asignados al servicio de esa celda */
+        .ing-count { display:inline-block; margin-left:4px; padding:0 5px; border-radius:8px; font-size:10px;
+                     font-weight:700; background:rgba(0,0,0,.12); vertical-align:middle; }
+        .ing-count i { font-size:9px; margin-right:2px; opacity:.8; }
         .celda-muted { background: #f1f3f5 !important; color: #adb5bd !important; }
         .celda-hoy { box-shadow: inset 0 0 0 2px #4e73df; }
         .nav-semana { display: flex; align-items: center; gap: 10px; }
@@ -280,6 +285,13 @@
             });
         }
 
+        // Escapa texto que se inserta como HTML (los datos del endpoint ya vienen escapados;
+        // esto cubre los campos que se arman aquí, como el nombre del ingeniero).
+        function esc(s) {
+            return String(s == null ? '' : s).replace(/&/g,'&amp;').replace(/</g,'&lt;')
+                                             .replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+        }
+
         // Badge con la Asignación (fija) del ingeniero, bajo su nombre
         function badgeAsignacion(asig) {
             if (!asig) return '<small class="asig-badge asig-none"><i class="fas fa-tag"></i> Sin asignación</small>';
@@ -288,7 +300,7 @@
             else if (a.indexOf('laboratorio') !== -1)   clase = 'asig-laboratorio';
             else if (a.indexOf('jefatura') !== -1)      clase = 'asig-jefatura';
             else if (a.indexOf('administ') !== -1)       clase = 'asig-administracion';
-            var txt = asig.replace(/</g,'&lt;').replace(/>/g,'&gt;');
+            var txt = esc(asig);
             return '<small class="asig-badge ' + clase + '" title="Asignación: ' + txt + '"><i class="fas fa-tag"></i> ' + txt + '</small>';
         }
 
@@ -303,7 +315,7 @@
         // Lab (departamento) del ingeniero, bajo el nombre junto a "Ver tablero".
         function labIng(lab) {
             if (!lab) return '';
-            var txt = String(lab).replace(/</g,'&lt;').replace(/>/g,'&gt;');
+            var txt = esc(lab);
             return '<small class="lab-ing" title="Laboratorio / departamento: ' + txt + '"><i class="fas fa-flask"></i> ' + txt + '</small>';
         }
 
@@ -335,15 +347,20 @@
             html += '</tr></thead><tbody>';
 
             ingenieros.forEach(function(ing) {
-                html += '<tr><td class="col-ing" title="' + ing.nombre + '">' + ing.nombre + badgeAsignacion(ing.asignacion) + linkTablero(ing.enlace, ing.id_usuario) + labIng(ing.lab) + '</td>';
+                var nom = esc(ing.nombre);
+                html += '<tr><td class="col-ing" title="' + nom + '">' + nom + badgeAsignacion(ing.asignacion) + linkTablero(ing.enlace, ing.id_real || ing.id_usuario) + labIng(ing.lab) + '</td>';
                 var celdasIng = celdas[ing.id_usuario] || {};
                 fechas.forEach(function(f) {
                     // Fin de semana: SIEMPRE disponible, sin importar servicio/lab/vacaciones/base.
                     var diaSem = new Date(f + 'T12:00:00').getDay(); // 0=dom, 6=sáb
                     var esFinSemana = (diaSem === 0 || diaSem === 6);
                     var info = esFinSemana ? null : celdasIng[f];
-                    // Sin evento en la celda -> estatus BASE del ingeniero (según su Asignación); default 'disponible'
-                    var estatus = esFinSemana ? 'disponible' : (info ? info.estatus : (ing.base || 'disponible'));
+                    // Sin evento en la celda -> 'En laboratorio' para TODOS (decisión del usuario 2026-08-05):
+                    // si un ingeniero no trae servicio, OT ni ausencia, se asume que está en su laboratorio.
+                    // Antes el default salía de la Asignación ('Servicio en sitio 100' -> disponible); ya no,
+                    // la Asignación se sigue mostrando como badge pero no decide el color de la celda.
+                    // El fin de semana sigue siendo 'disponible' (regla previa, no se tocó).
+                    var estatus = esFinSemana ? 'disponible' : (info ? info.estatus : 'enlaboratorio');
                     var meta = ESTATUS_META[estatus] || ESTATUS_META.disponible;
                     var claseHoy = (f === hoy) ? ' celda-hoy' : '';
                     var detalle = (info && info.detalle) ? info.detalle : '';
@@ -356,7 +373,11 @@
                         // Con popup (servicio) -> tooltip Bootstrap HTML en la celda; sin popup -> title nativo en el detalle
                         var det = detalle ? '<small' + (titulo ? '' : ' title="' + detalle.replace(/"/g,'&quot;') + '"') + '>' + detalle + '</small>' : '';
                         var ttAttr = titulo ? ' data-toggle="tooltip" data-html="true" title="' + titulo.replace(/"/g,'&quot;') + '"' : '';
-                        html += '<td class="celda-disp' + claseHoy + '"' + ttAttr + ' style="background:' + meta.bg + ';color:' + meta.fg + ';">' + meta.label + det + '</td>';
+                        // Cuántos ingenieros están asignados a ese servicio (el popup los lista por nombre)
+                        var nIngs = (info && info.ings) ? info.ings : 0;
+                        var badgeIngs = (estatus === 'servicio' && nIngs) ?
+                            ' <span class="ing-count"><i class="fas fa-users"></i>' + nIngs + '</span>' : '';
+                        html += '<td class="celda-disp' + claseHoy + '"' + ttAttr + ' style="background:' + meta.bg + ';color:' + meta.fg + ';">' + meta.label + badgeIngs + det + '</td>';
                     }
                 });
                 html += '</tr>';

--- a/disponibilidadVehiculos.php
+++ b/disponibilidadVehiculos.php
@@ -1,8 +1,9 @@
 <?php
     session_start();
     include 'conn.php';
-    if($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null){
+    if(!isset($_COOKIE['noEmpleado']) || $_COOKIE['noEmpleado'] == ''){
         echo '<script>window.location.assign("index")</script>';
+        exit;   // sin exit la página se seguía enviando completa antes de que el navegador redirigiera
     }
 ?>
 <!DOCTYPE html>
@@ -32,6 +33,8 @@
         .grid-disp tbody tr { border-bottom: 2px solid #dee2e6; }
         .celda-disp { min-height: 46px; line-height: 1.25; font-size: 11px; font-weight: 600; }
         .celda-disp small { display:block; font-weight: 400; font-size: 10px; opacity: 0.85; }
+        /* Ícono de uso: quién trae el vehículo ese día (su responsable vs alguien más) */
+        .uso-icono { margin-right: 4px; opacity: .75; }
         .celda-muted { background: #f1f3f5 !important; color: #adb5bd !important; }
         .celda-hoy { box-shadow: inset 0 0 0 2px #4e73df; }
         .nav-semana { display: flex; align-items: center; gap: 10px; }
@@ -93,6 +96,10 @@
                         <span class="badge" style="background:#d0ebff;color:#0b4f8a;">En servicio</span>
                         <span class="badge" style="background:#ffd8a8;color:#8a3b00;">En préstamo</span>
                         <span class="badge" style="background:#d0bfff;color:#5f3dc4;">En mantenimiento</span>
+                        <span class="ms-3 text-muted">
+                            <i class="fas fa-user"></i> lo trae su responsable &nbsp;·&nbsp;
+                            <i class="fas fa-handshake"></i> lo trae alguien más (préstamo u otro ingeniero)
+                        </span>
                     </div>
 
                     <div id="contenedorGrid" style="overflow-x:auto;">
@@ -216,11 +223,17 @@
                 }
             });
         }
+        // Escapa texto que se inserta como HTML (los datos del endpoint ya vienen escapados;
+        // esto cubre los campos de inventario que se arman aquí: placa, marca, modelo, responsable).
+        function esc(s) {
+            return String(s == null ? '' : s).replace(/&/g,'&amp;').replace(/</g,'&lt;')
+                                             .replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+        }
         function poblarFiltroVehiculos(vehiculos, reemplazar) {
             var sel = $('#filtro-vehiculo');
             if (reemplazar) sel.empty();
             vehiculos.forEach(function(v) {
-                var etiqueta = (v.placa || 'S/P') + ' · ' + [v.marca, v.modelo].filter(Boolean).join(' ');
+                var etiqueta = esc((v.placa || 'S/P') + ' · ' + [v.marca, v.modelo].filter(Boolean).join(' '));
                 sel.append('<option value="' + v.id_vehiculo + '">' + etiqueta + '</option>');
             });
             sel.trigger('change.select2');
@@ -303,11 +316,11 @@
             html += '</tr></thead><tbody>';
 
             pageRows.forEach(function(veh) {
-                var titulo = (veh.placa || 'S/P') + ' — ' + [veh.marca, veh.modelo].filter(Boolean).join(' ');
-                var sub = [ [veh.marca, veh.modelo].filter(Boolean).join(' '), veh.usuario ].filter(Boolean).join(' · ');
+                var titulo = esc((veh.placa || 'S/P') + ' — ' + [veh.marca, veh.modelo].filter(Boolean).join(' '));
+                var sub = esc([ [veh.marca, veh.modelo].filter(Boolean).join(' '), veh.usuario ].filter(Boolean).join(' · '));
                 var esComodin = (veh.comodin == 1);
                 var badgeCom = esComodin ? ' <span class="badge-comodin">Comodín</span>' : '';
-                html += '<tr' + (esComodin ? ' class="fila-comodin"' : '') + '><td class="col-veh" title="' + titulo.replace(/"/g,'&quot;') + '">' + (veh.placa || 'S/P') + badgeCom +
+                html += '<tr' + (esComodin ? ' class="fila-comodin"' : '') + '><td class="col-veh" title="' + titulo + '">' + esc(veh.placa || 'S/P') + badgeCom +
                         '<small>' + sub + '</small></td>';
                 var celdasVeh = celdas[veh.id_vehiculo] || {};
                 fechas.forEach(function(f) {
@@ -325,7 +338,11 @@
                     var titulo = (info && info.titulo) ? info.titulo : detalle;
                     var det = detalle ? '<small>' + detalle + '</small>' : '';
                     var ttAttr = titulo ? ' data-toggle="tooltip" data-html="true" title="' + titulo.replace(/"/g,'&quot;') + '"' : '';
-                    html += '<td class="celda-disp' + claseHoy + '"' + ttAttr + ' style="background:' + meta.bg + ';color:' + meta.fg + ';">' + meta.label + det + '</td>';
+                    // Ícono de uso: 👤 lo trae su responsable de inventario · 🤝 lo trae alguien más
+                    var uso = (info && info.uso) ? info.uso : '';
+                    var icono = uso === 'asignado' ? '<i class="fas fa-user uso-icono"></i>' :
+                                uso === 'otro'     ? '<i class="fas fa-handshake uso-icono"></i>' : '';
+                    html += '<td class="celda-disp' + claseHoy + '"' + ttAttr + ' style="background:' + meta.bg + ';color:' + meta.fg + ';">' + icono + meta.label + det + '</td>';
                 });
                 html += '</tr>';
             });

--- a/lib_ot_interna.php
+++ b/lib_ot_interna.php
@@ -1,0 +1,170 @@
+<?php
+// Lógica compartida de importación del reporte de OT internas -> tabla `planeacion_ot_interna`.
+// La usan DOS entradas, para que ambas se comporten idéntico:
+//   - `cargar_ot_interna.php`  (línea de comandos)
+//   - `procesar_ot_interna.php` (subida desde el navegador; la pantalla es `carga_sabana.php`)
+// La tabla la lee el grid de Disponibilidad de Ingenieros (bloque 3c de acciones_disponibilidad.php),
+// que pinta las celdas moradas "OT interna".
+
+// Normaliza un nombre para compararlo: sin acentos, sin mayúsculas, sin signos ni espacios de más.
+// Debe coincidir con la normalización del endpoint, o el diagnóstico mentiría.
+function otiNormalizarNombre($s) {
+    $s = mb_strtolower(trim((string)$s), 'UTF-8');
+    $s = strtr($s, ['á'=>'a','é'=>'e','í'=>'i','ó'=>'o','ú'=>'u','ü'=>'u','ñ'=>'n',
+                    'à'=>'a','è'=>'e','ì'=>'i','ò'=>'o','ù'=>'u']);
+    $s = preg_replace('/[^a-z0-9 ]+/', ' ', $s);
+    return trim(preg_replace('/\s+/', ' ', $s));
+}
+
+// Importa el CSV. Devuelve un arreglo con el resultado; NUNCA lanza excepción hacia afuera.
+//   ok, mensaje, filas, omitidas, rango{min,max}, sin_match{nombre => veces}
+function otiImportar(mysqli $conn, $ruta) {
+    $r = ['ok' => false, 'mensaje' => '', 'filas' => 0, 'omitidas' => 0, 'sin_fecha' => 0,
+          'rango' => ['min' => null, 'max' => null], 'sin_match' => []];
+
+    if (!is_file($ruta) || !is_readable($ruta)) {
+        $r['mensaje'] = 'No se pudo leer el archivo.';
+        return $r;
+    }
+
+    // El reporte puede venir de Excel en Windows-1252; si no es UTF-8 válido se convierte, porque
+    // si no los nombres con acento nunca casarían contra `usuarios` y se perderían OT.
+    $contenido = file_get_contents($ruta);
+    if ($contenido === false) { $r['mensaje'] = 'No se pudo leer el archivo.'; return $r; }
+    if (!mb_check_encoding($contenido, 'UTF-8')) {
+        $contenido = mb_convert_encoding($contenido, 'UTF-8', 'Windows-1252');
+    }
+    $fh = fopen('php://temp', 'r+');
+    fwrite($fh, $contenido);
+    rewind($fh);
+
+    $headers = fgetcsv($fh);
+    if (!$headers) { fclose($fh); $r['mensaje'] = 'El archivo está vacío o no se pudo leer.'; return $r; }
+    $headers = array_map(function ($h) { return trim($h, " \t\r\n\xEF\xBB\xBF"); }, $headers);
+    $idx = array_flip($headers);
+    if (!isset($idx['orderCode'])) {
+        fclose($fh);
+        $r['mensaje'] = 'Este archivo no parece el reporte de OT internas: no trae la columna "orderCode". '
+                      . 'Columnas encontradas: ' . implode(', ', array_slice($headers, 0, 8)) . '…';
+        return $r;
+    }
+    $col = function ($row, $name) use ($idx) {
+        return isset($idx[$name]) && isset($row[$idx[$name]]) ? trim($row[$idx[$name]]) : null;
+    };
+
+    // El reporte usa 'S/R' y "'-" como "sin registro"; se guardan como NULL.
+    $esVacio = function ($v) {
+        $v = trim((string)$v);
+        return $v === '' || strcasecmp($v, 'S/R') === 0 || $v === '-' || $v === "'-";
+    };
+    // El formato de fecha del export YA CAMBIÓ una vez (era "20/07/2026 08:00" y pasó a
+    // "2026-01-02  08:41 AM", con doble espacio y AM/PM). Cuando eso pasó, TODAS las fechas entraron
+    // como NULL y el tablero se quedó en blanco sin ningún error. Por eso se prueban varios formatos
+    // y se cuenta aparte cuántas OT quedaron sin fecha (ver 'sin_fecha' en el resultado).
+    $parseFecha = function ($v) use ($esVacio) {
+        if ($esVacio($v)) return null;
+        $s = trim(preg_replace('/\s+/', ' ', (string)$v));
+        if ($s === '' || strpos($s, '0000-00-00') === 0) return null;
+        foreach (['d/m/Y H:i', 'Y-m-d h:i A', 'Y-m-d H:i:s', 'Y-m-d H:i', 'd/m/Y', 'Y-m-d'] as $f) {
+            $dt = DateTime::createFromFormat($f, $s);
+            $err = DateTime::getLastErrors();   // en PHP 8 devuelve false cuando no hubo problemas
+            if ($dt && (!$err || ($err['warning_count'] === 0 && $err['error_count'] === 0))) {
+                return $dt->format('Y-m-d H:i:s');
+            }
+        }
+        return null;
+    };
+    $limpiaNum = function ($v) use ($esVacio) { return $esVacio($v) ? null : trim($v); };
+
+    // Nombres de los ingenieros activos, para avisar cuáles del reporte NO van a casar.
+    // El cruce del grid es POR NOMBRE (la columna `Engineers` guarda texto, no ids), así que un
+    // typo en el reporte hace que esa OT no se le pinte a nadie y nadie se entera.
+    $conocidos = [];
+    $q = $conn->query("SELECT nombres, apellidos, nombre FROM usuarios
+                       WHERE estatus = 1 AND tipo_usr IN ('ING','JEFE_ENCARGADO','JEFE_LAB')");
+    if ($q) {
+        while ($u = $q->fetch_assoc()) {
+            foreach ([trim($u['nombres'] . ' ' . $u['apellidos']),
+                      trim($u['apellidos'] . ' ' . $u['nombres']),
+                      $u['nombre']] as $cand) {
+                $k = otiNormalizarNombre($cand);
+                if ($k !== '') $conocidos[$k] = true;
+            }
+        }
+    }
+
+    $sql = "INSERT INTO planeacion_ot_interna
+            (codigo_ot,estatus,areas_calidad,ingenieros,fecha_creacion,fecha_compromiso,fecha_inicio,fecha_fin,fecha_cierre,tiempo_estimado,tiempo_trabajado,tiempo_registrado)
+            VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
+            ON DUPLICATE KEY UPDATE estatus=VALUES(estatus), areas_calidad=VALUES(areas_calidad), ingenieros=VALUES(ingenieros),
+                fecha_creacion=VALUES(fecha_creacion), fecha_compromiso=VALUES(fecha_compromiso), fecha_inicio=VALUES(fecha_inicio), fecha_fin=VALUES(fecha_fin),
+                fecha_cierre=VALUES(fecha_cierre), tiempo_estimado=VALUES(tiempo_estimado), tiempo_trabajado=VALUES(tiempo_trabajado), tiempo_registrado=VALUES(tiempo_registrado)";
+    $stmt = $conn->prepare($sql);
+    if (!$stmt) {
+        fclose($fh);
+        $r['mensaje'] = 'No existe la tabla `planeacion_ot_interna` o no se pudo preparar la consulta: ' . $conn->error;
+        return $r;
+    }
+
+    while (($row = fgetcsv($fh)) !== false) {
+        if (count(array_filter($row, function ($x) { return trim((string)$x) !== ''; })) === 0) continue;
+        $orderCode = $col($row, 'orderCode');
+        if ($orderCode === null || $orderCode === '') { $r['omitidas']++; continue; }
+
+        // Sin fecha de inicio la OT se guarda pero NO se puede pintar en el tablero (no se sabe qué día).
+        $fIni = $parseFecha($col($row, 'startDate'));
+        if ($fIni !== null) {
+            $d = substr($fIni, 0, 10);
+            if ($r['rango']['min'] === null || $d < $r['rango']['min']) $r['rango']['min'] = $d;
+            if ($r['rango']['max'] === null || $d > $r['rango']['max']) $r['rango']['max'] = $d;
+        } else {
+            $r['sin_fecha']++;
+        }
+
+        // Diagnóstico: ¿cada nombre del reporte existe en `usuarios`? (mismos separadores que el grid)
+        $ingsTxt = (string)$col($row, 'Engineers');
+        foreach (preg_split('/[,;\/&]| y /u', $ingsTxt) as $parte) {
+            $k = otiNormalizarNombre($parte);
+            if ($k === '') continue;
+            if (!isset($conocidos[$k])) {
+                $limpio = trim($parte);
+                $r['sin_match'][$limpio] = ($r['sin_match'][$limpio] ?? 0) + 1;
+            }
+        }
+
+        $vals = [
+            $orderCode,
+            $col($row, 'status'),
+            $col($row, 'qualityAreas'),
+            $ingsTxt,
+            $parseFecha($col($row, 'created')),
+            $parseFecha($col($row, 'dueDate')),
+            $fIni,
+            $parseFecha($col($row, 'endDate')),
+            $parseFecha($col($row, 'closeDate')),
+            $limpiaNum($col($row, 'estimatedTime')),
+            $limpiaNum($col($row, 'workTime')),
+            $limpiaNum($col($row, 'timedTime')),
+        ];
+        $stmt->bind_param('ssssssssssss', ...$vals);
+        if ($stmt->execute()) { $r['filas']++; } else { $r['omitidas']++; }
+    }
+    $stmt->close();
+    fclose($fh);
+
+    if ($r['filas'] === 0 && $r['omitidas'] === 0) {
+        $r['mensaje'] = 'El archivo no traía ningún renglón de datos.';
+        return $r;
+    }
+    // Si NINGUNA fecha se pudo leer, el formato del export cambió: se importó pero el tablero
+    // quedaría en blanco. Vale más fallar ruidosamente que dejarlo pasar.
+    if ($r['filas'] > 0 && $r['sin_fecha'] === $r['filas']) {
+        $r['mensaje'] = 'Se leyeron ' . $r['filas'] . ' OT pero NINGUNA traía una fecha de inicio reconocible: '
+                      . 'seguramente cambió el formato de fecha del reporte. Los datos se guardaron, pero '
+                      . 'no se pintarán en el tablero hasta corregir la lectura de fechas.';
+        return $r;   // ok = false a propósito: es un fallo, aunque haya filas
+    }
+    arsort($r['sin_match']);
+    $r['ok'] = true;
+    return $r;
+}

--- a/menu.php
+++ b/menu.php
@@ -105,6 +105,13 @@
                     <span>Dispo. de Vehículos</span>
                 </a>
             </li>
+
+            <li class="nav-item">
+                <a class="nav-link" href="carga_sabana">
+                    <i class="fas fa-fw fa-file-upload text-warning"></i>
+                    <span>Carga de archivos</span>
+                </a>
+            </li>
             <li class="nav-item">
                 <a class="nav-link" href="canva">
                     <i class="fas fa-fw fa-file-upload text-gray-400"></i>

--- a/procesar_ot_interna.php
+++ b/procesar_ot_interna.php
@@ -1,0 +1,56 @@
+<?php
+header('Content-Type: application/json');
+// Recibe el reporte de OT internas subido desde la tarjeta de `carga_sabana.php` y lo importa.
+// La importación en sí vive en `lib_ot_interna.php`, la misma que usa el CLI `cargar_ot_interna.php`.
+
+// Acceso: exige sesión iniciada (cookie noEmpleado), igual que el resto del módulo.
+$noEmpleado_cookie = isset($_COOKIE['noEmpleado']) ? trim($_COOKIE['noEmpleado']) : '';
+if ($noEmpleado_cookie === '' || !ctype_digit($noEmpleado_cookie)) {
+    http_response_code(401);
+    echo json_encode(['status' => 'error', 'message' => 'Sesión no válida. Vuelve a iniciar sesión.']);
+    exit;
+}
+
+require __DIR__ . '/conn.php';
+require __DIR__ . '/lib_ot_interna.php';
+mysqli_set_charset($conn, 'utf8mb4');
+
+if (!isset($_FILES['archivo']) || $_FILES['archivo']['error'] !== UPLOAD_ERR_OK) {
+    // El error más común aquí es que el archivo pase de upload_max_filesize/post_max_size del php.ini
+    $errores = [
+        UPLOAD_ERR_INI_SIZE   => 'El archivo excede el tamaño máximo permitido por el servidor.',
+        UPLOAD_ERR_FORM_SIZE  => 'El archivo excede el tamaño máximo del formulario.',
+        UPLOAD_ERR_PARTIAL    => 'El archivo se subió incompleto. Intenta de nuevo.',
+        UPLOAD_ERR_NO_FILE    => 'No seleccionaste ningún archivo.',
+        UPLOAD_ERR_NO_TMP_DIR => 'El servidor no tiene carpeta temporal configurada.',
+        UPLOAD_ERR_CANT_WRITE => 'El servidor no pudo escribir el archivo temporal.',
+    ];
+    $cod = isset($_FILES['archivo']) ? $_FILES['archivo']['error'] : UPLOAD_ERR_NO_FILE;
+    echo json_encode(['status' => 'error', 'message' => $errores[$cod] ?? 'No se pudo recibir el archivo.']);
+    exit;
+}
+
+$nombreOriginal = $_FILES['archivo']['name'];
+$ext = strtolower(pathinfo($nombreOriginal, PATHINFO_EXTENSION));
+if ($ext !== 'csv') {
+    echo json_encode(['status' => 'error',
+                      'message' => 'El reporte debe ser un archivo .csv (recibí ".' . htmlspecialchars($ext) . '"). '
+                                 . 'Si lo tienes en Excel, guárdalo como CSV.']);
+    exit;
+}
+
+// Se lee directo del archivo temporal de PHP: no hace falta conservarlo en el servidor.
+$r = otiImportar($conn, $_FILES['archivo']['tmp_name']);
+if (!$r['ok']) {
+    echo json_encode(['status' => 'error', 'message' => $r['mensaje']]);
+    exit;
+}
+
+echo json_encode([
+    'status'    => 'success',
+    'archivo'   => $nombreOriginal,
+    'filas'     => $r['filas'],
+    'omitidas'  => $r['omitidas'],
+    'rango'     => $r['rango'],
+    'sin_match' => $r['sin_match'],
+]);


### PR DESCRIPTION
…mpromiso y carga  web

Ingenieros:
- Las celdas de Servicio muestran cuantos ingenieros ACOMPAÑAN (el del renglon se excluye) y el popup los lista por nombre.
- El servicio de campo ahora le gana a la OT interna, que antes lo tapaba; la OT se anota al pie del popup.
- Las OT internas ocupan de fecha_inicio a fecha_compromiso (se ignora endDate) y las canceladas liberan la celda.
- Los 6 ingenieros con id_usuario vacio recuperan su renglon: el grid agrupa por una clave sintetica y pasa de 90 a 96 renglones.
- El estatus predeterminado sin evento pasa de "Disponible" a "En laboratorio"; se elimina el estatus base derivado de la Asignacion.

Vehiculos:
- Cada celda ocupada indica quien trae el vehiculo: su responsable de inventario o alguien mas (prestamo u otro ingeniero).
- El popup de prestamo resuelve el nombre de quien lo pidio.

Carga del reporte de OT internas desde el navegador:
- Nueva tarjeta en carga_sabana.php con el estado del reporte y aviso de los nombres que no existen en usuarios.
- La importacion se extrae a lib_ot_interna.php, compartida por la consola y la web (procesar_ot_interna.php).
- Se corrige la lectura de fechas: el export cambio de formato y el parser devolvia NULL en todas, dejando el tablero en blanco sin ningun error.